### PR TITLE
Fixup the chromosome zarr encoding bug

### DIFF
--- a/src/caduceus_inf.py
+++ b/src/caduceus_inf.py
@@ -175,7 +175,8 @@ def generate_soft_labels(
                     "sample": batch_indices,
                     "sequence": range(input_ids.shape[1]),
                     "vocab": range(logits.shape[-1]),
-                    "chr_name": (["sample"], list(chr_names)),
+                    # NOTE: use U5 encoding because chr name can be either 3 or 4 characters long, e.g. `chr1` or `chr10`
+                    "chr_name": (["sample"], list(chr_names), {}, {"dtype": "U5"}),
                     "start": (["sample"], [int(s) for s in starts]),
                     "end": (["sample"], [int(e) for e in ends]),
                 },


### PR DESCRIPTION
If we start the inference from the beginning (i.e. `chr1`) we encode `chr_name` as `<U4`, but at some point `<U5` is required.

Below is the list of all the `chr_name`:

> {'chr1', 'chrX', 'chr13', 'chr16', 'chr4', 'chr7', 'chr14', 'chr11', 'chr22', 'chr20', 'chr17', 'chr2', 'chr15', 'chr10', 'chr19', 'chr5', 'chr9', 'chr21', 'chr12', 'chr8', 'chr6', 'chr18', 'chr3'}

@yonromai I originally thought it was the token character, but it's actually the chromosome name, which is a lot more useful downstream, so we should keep it :)