### PR TITLE
Do not store/compute probabilities

### DIFF
--- a/src/caduceus_inf.py
+++ b/src/caduceus_inf.py
@@ -184,7 +184,6 @@ def generate_soft_labels(
             with torch.inference_mode(), autocast(enabled=(device == "cuda")):
                 outputs = model(input_ids)
                 logits = outputs.logits
-                probabilities = torch.softmax(logits.float(), dim=-1)
 
             if nvml_available and pynvml is not None:
                 try:
@@ -206,10 +205,6 @@ def generate_soft_labels(
                 {
                     "input_ids": (["sample", "sequence"], input_ids.cpu().numpy()),
                     "logits": (["sample", "sequence", "vocab"], logits.cpu().numpy()),
-                    "probabilities": (
-                        ["sample", "sequence", "vocab"],
-                        probabilities.cpu().numpy(),
-                    ),
                 },
                 coords={
                     "sample": batch_indices,


### PR DESCRIPTION
They are not immediately useful (for our current effort), and we can easily compute them adhoc from the logits. The major downside of storing them, is that they take quite a bit of space/IO, especially for full hg38. For reference, using the current code, for full hg38, the `probabilities` zarr group would require more than 100GB on disk. Obviously there's many ways to reduce that size, but I would argue, that's not that interesting and useful for us ATM.