### PR TITLE
Freeze hyper-parameters temp and alpha for evaluations

### DIFF
--- a/src/caduceus_distillation.py
+++ b/src/caduceus_distillation.py
@@ -187,8 +187,12 @@ class StudentCaduceus(L.LightningModule):
             student_logits,
             teacher_logits,
             input_ids,
-            temperature=self.temperature,
-            alpha=self.alpha,
+            # The `temp` hyper-parameter should not affect the eval scoring
+            # Also, temp should be set to 1.0 after the distillation is complete (per Hinton)
+            temperature=1.0,
+            # The `alpha` hyper-parameter should not affect the eval scoring
+            # alpha=1.0 means that we only consider the soft targets
+            alpha=1.0,
         )
 
         self.log("val_loss", loss, on_step=False, on_epoch=True, prog_bar=True)


### PR DESCRIPTION
Rationale: It's preferable, in order to be able to compare/tune the effect of hyper-parameters, to exclude them from the eval calculation.

Notes:
- Hinton suggests temp to be set to 1 after the model is trained (so that's the value we use to compute evals):
> The same high temperature is used when training the distilled model, but after it has been trained it uses a temperature of 1. 

- In order to remove `alpha` from the eval, we set it to 1.0. Consequently, we only consider the KL div on the soft targets and ignore the hard targets CE term.



