### PR TITLE
Fixup distill loss - KL div scaling

### DIFF
--- a/src/tests/caduceus_distillation_test.py
+++ b/src/tests/caduceus_distillation_test.py
@@ -46,7 +46,7 @@ def test_temperature_scaling(basic_inputs):
         torch.argmax(teacher, dim=-1).view(-1),
         # NOTE: match the `batchmean`` behavior of KL divergence, first sum then divide by batch size
         reduction="sum",
-    ) / student.size(0)
+    ) / (student.size(0) * student.size(1))
     assert torch.isclose(loss_low_temp, hard_loss)
 
 


### PR DESCRIPTION
Some resources first:
 * pytorch implementation of `kl_div`:
    * https://github.com/pytorch/pytorch/blob/3ee75b7eacef6758db602e87287ef9574609b327/torch/nn/functional.py#L3374     
    * https://github.com/pytorch/pytorch/blob/2860f5c4f5328224ab7998bc90b9fb395b5b068b/aten/src/ATen/native/Loss.cpp#L246

We need to make sure that the 1st dimension has correct size, to get correct `kl_div`, the code before we averaging across batches only, which would sum across both sequence and vocabulary. This PR fixes it by flattening the first 2 dimensions much like we already do in the cross entropy.