### PR TITLE
Prioritize downstream tasks suggested by Eric

### DIFF
--- a/src/caduceus_nt_eval.py
+++ b/src/caduceus_nt_eval.py
@@ -179,19 +179,24 @@ def load_caduceus(
 TASK_GROUPS = {
     # Tasks from https://huggingface.co/datasets/InstaDeepAI/nucleotide_transformer_downstream_tasks_revised
     "enhancers_only": ["enhancers"],
+    "eric_relevant": [
+        "splice_sites_acceptors",
+        "splice_sites_donors",
+    ],
     "representative_binary_tasks": [
+        "splice_sites_acceptors",
+        "splice_sites_donors",
         "enhancers",
         "promoter_all",
-        "splice_sites_acceptors",
         "H3K4me3",
     ],
     "all_binary_tasks": [
+        "splice_sites_acceptors",
+        "splice_sites_donors",
         "promoter_all",
         "promoter_tata",
         "promoter_no_tata",
         "enhancers",
-        "splice_sites_acceptors",
-        "splice_sites_donors",
         "H2AFZ",
         "H3K27ac",
         "H3K27me3",

--- a/src/config.yaml
+++ b/src/config.yaml
@@ -4,7 +4,7 @@ task_limit: null
 chunk_size: 100
 disable_fused_add_norm: true
 random: false
-task_group: representative_binary_tasks
+task_group: eric_relevant
 hydra:
   run:
     dir: data/run/${hydra.job.override_dirname}


### PR DESCRIPTION
From https://gist.github.com/eric-czech/7a368d2b2503b726a91510787f4fc373#file-caduceus_nt_eval_example-py:
> Time-permitting, the simplest, relevant downstream evaluation would be on the "splice_sites_acceptors" and "splice_sites_donors" tasks of the [NT-benchmark dataset](https://huggingface.co/spaces/InstaDeepAI/nucleotide_transformer_benchmark)


2 changes:
 * put both `splice_sites_acceptors` and `splice_sites_donors` at the top of both `representative_binary_tasks` and `all_binary_tasks` tasks groups. Such that with limit set to e.g. 2, you always get the "relevant" tasks
 * introduce `eric_relevant` task group, with only `splice_sites_acceptors` and `splice_sites_donors`