### PR TITLE
Distill via embeddings

### DIFF
--- a/caduceus_distill/tests/caduceus_distillation_test.py
+++ b/caduceus_distill/tests/caduceus_distillation_test.py
@@ -13,40 +13,88 @@ from caduceus_distill.distill import (
 
 @pytest.fixture
 def basic_inputs():
-    B, S, V = 2, 5, 16  # Batch size, Sequence length, Vocabulary size
+    B, S, V, D = (
+        2,
+        5,
+        16,
+        32,
+    )  # Batch size, Sequence length, Vocabulary size, Hidden size
     student = torch.randn(B, S, V)
+    student_hidden = torch.randn(B, S, D)
     teacher = torch.randn(B, S, V)
+    teacher_hidden = torch.randn(B, S, D)
     # 7 to 10 represent the valid nucleotide token IDs, it doesn't really matter for the test
     # but we do test some `non-specific` nucleotide (token ID 11)
     targets = torch.randint(7, 11, (B, S))
-    return student, teacher, targets
+    return student, student_hidden, teacher, teacher_hidden, targets
 
 
 def test_happy_path(basic_inputs):
-    student, teacher, targets = basic_inputs
-    loss, _, _ = distillation_loss(student, teacher, targets)
+    student, student_hidden, teacher, teacher_hidden, targets = basic_inputs
+    loss, _, _, _ = distillation_loss(
+        student_logits=student,
+        student_emb=student_hidden,
+        teacher_logits=teacher,
+        teacher_emb=teacher_hidden,
+        input_ids=targets,
+        temperature=4.0,
+        alpha_soft=1.0,
+        alpha_sim=0.0,
+    )
     assert torch.isfinite(loss)
     assert loss.shape == ()
 
 
 def test_temperature_scaling(basic_inputs):
-    student, teacher, targets = basic_inputs
-    loss1, _, _ = distillation_loss(student, teacher, targets, temperature=1.0)
-    loss4, _, _ = distillation_loss(student, teacher, targets, temperature=4.0)
+    student, student_hidden, teacher, teacher_hidden, targets = basic_inputs
+    loss1, _, _, _ = distillation_loss(
+        student_logits=student,
+        student_emb=student_hidden,
+        teacher_logits=teacher,
+        teacher_emb=teacher_hidden,
+        input_ids=targets,
+        temperature=1.0,
+        alpha_soft=1.0,
+        alpha_sim=0.0,
+    )
+    loss4, _, _, _ = distillation_loss(
+        student_logits=student,
+        student_emb=student_hidden,
+        teacher_logits=teacher,
+        teacher_emb=teacher_hidden,
+        input_ids=targets,
+        temperature=4.0,
+        alpha_soft=1.0,
+        alpha_sim=0.0,
+    )
     assert not torch.allclose(loss1, loss4)
 
     # NOTE: If temp tends to infinity, softmax should be close to uniform,
     # and with alpha=1.0 (soft target loss only), the loss should be 0
-    loss_high_temp, _, _ = distillation_loss(
-        student, teacher, targets, temperature=1e9, alpha=1.0
+    loss_high_temp, _, _, _ = distillation_loss(
+        student_logits=student,
+        student_emb=teacher_hidden,
+        teacher_logits=teacher,
+        teacher_emb=teacher_hidden,
+        input_ids=targets,
+        temperature=1e9,
+        alpha_soft=1.0,
+        alpha_sim=0.0,
     )
     assert torch.isclose(loss_high_temp, torch.tensor(0.0))
 
     # NOTE: if temp is very low, softmax should be close to one-hot encoding,
     # and so soft loss will tend to hard loss for scaled logits
     small_temp = 1e-9
-    loss_low_temp, _, _ = distillation_loss(
-        student, teacher, targets, temperature=small_temp, alpha=1.0
+    loss_low_temp, _, _, _ = distillation_loss(
+        student_logits=student,
+        student_emb=teacher_hidden,
+        teacher_logits=teacher,
+        teacher_emb=teacher_hidden,
+        input_ids=targets,
+        temperature=small_temp,
+        alpha_soft=1.0,
+        alpha_sim=0.0,
     )
 
     useful_class_idx = [CADUCEUS_PAD_TOKEN_ID, 10, 9, 8, 7]
@@ -64,19 +112,46 @@ def test_temperature_scaling(basic_inputs):
 
 
 def test_invalid_inputs(basic_inputs):
-    student, teacher, targets = basic_inputs
+    student, student_emb, teacher, teacher_emb, targets = basic_inputs
     with pytest.raises(
         AssertionError, match="Expected student_logits to be 3D, got 2D"
     ):
-        distillation_loss(student[0], teacher, targets)
+        distillation_loss(
+            student_logits=student[0],
+            student_emb=student_emb[0],
+            teacher_logits=teacher,
+            teacher_emb=teacher_emb,
+            input_ids=targets,
+            temperature=4.0,
+            alpha_soft=1.0,
+            alpha_sim=0.0,
+        )
     with pytest.raises(AssertionError, match="Temperature must be positive"):
-        distillation_loss(student, teacher, targets, temperature=-1.0)
-    with pytest.raises(AssertionError, match=re.escape("Alpha must be in [0, 1]")):
-        distillation_loss(student, teacher, targets, alpha=1.1)
+        distillation_loss(
+            student_logits=student,
+            student_emb=student_emb,
+            teacher_logits=teacher,
+            teacher_emb=teacher_emb,
+            input_ids=targets,
+            temperature=-1.0,
+            alpha_soft=1.0,
+            alpha_sim=0.0,
+        )
+    with pytest.raises(AssertionError, match=re.escape("alpha_soft must be in [0, 1]")):
+        distillation_loss(
+            student_logits=student,
+            student_emb=student_emb,
+            teacher_logits=teacher,
+            teacher_emb=teacher_emb,
+            input_ids=targets,
+            temperature=4.0,
+            alpha_soft=1.1,
+            alpha_sim=0.0,
+        )
 
 
 def test_filter_non_specific_nucleotides(basic_inputs):
-    student, teacher, targets = basic_inputs
+    student_logits, student_emb, teacher_logits, teacher_emb, targets = basic_inputs
 
     original_num_targests = targets.numel()
     # randomly set 10% of the targets to a special token CADUCEUS_NON_SPECIFIC_NUCLEOTIDE_TOKEN_ID
@@ -86,34 +161,49 @@ def test_filter_non_specific_nucleotides(basic_inputs):
 
     assert torch.any(targets == CADUCEUS_PAD_TOKEN_ID)
 
-    assert student.ndim == 3
-    assert teacher.ndim == 3
+    assert student_logits.ndim == 3
+    assert teacher_logits.ndim == 3
     assert targets.ndim == 2
 
-    student, teacher, targets = _filter_non_specific_nucleotides_and_batch(
-        student, teacher, targets
+    student_logits, teacher_logits, student_emb, teacher_emb, targets = (
+        _filter_non_specific_nucleotides_and_batch(
+            student_logits=student_logits,
+            teacher_logits=teacher_logits,
+            student_emb=student_emb,
+            teacher_emb=teacher_emb,
+            input_ids=targets,
+        )
     )
 
     # Check that the non-specific nucleotide token is filtered out
     assert not torch.any(targets == CADUCEUS_PAD_TOKEN_ID)
-    assert student.ndim == 2
-    assert teacher.ndim == 2
+    assert student_logits.ndim == 2
+    assert teacher_logits.ndim == 2
     assert targets.ndim == 1
-    assert student.size(0) == teacher.size(0) == targets.size(0)
-    assert student.size(1) == teacher.size(1)
+    assert student_logits.size(0) == teacher_logits.size(0) == targets.size(0)
+    assert student_logits.size(1) == teacher_logits.size(1)
 
-    assert original_num_targests - num_non_specific == student.size(0)
+    assert original_num_targests - num_non_specific == student_logits.size(0)
 
 
 def test_filter_non_specific_nucleotides_filter_all(basic_inputs):
-    student, teacher, targets = basic_inputs
+    student_logits, student_emb, teacher_logits, teacher_emb, targets = basic_inputs
 
     # Set all targets to a non-specific nucleotide token
     targets.fill_(CADUCEUS_PAD_TOKEN_ID)
 
-    student, teacher, targets = _filter_non_specific_nucleotides_and_batch(
-        student, teacher, targets
+    student_logits, teacher_logits, student_emb, teacher_emb, targets = (
+        _filter_non_specific_nucleotides_and_batch(
+            student_logits=student_logits,
+            teacher_logits=teacher_logits,
+            student_emb=student_emb,
+            teacher_emb=teacher_emb,
+            input_ids=targets,
+        )
     )
 
     assert targets.size(0) == 0
-    assert student.size(0) == 0
+    assert student_logits.size(0) == 0
+    assert teacher_logits.size(0) == 0
+    assert student_emb.size(0) == 0
+    assert teacher_emb.size(0) == 0

--- a/caduceus_distill/tests/caduceus_distillation_test.py
+++ b/caduceus_distill/tests/caduceus_distillation_test.py
@@ -202,6 +202,8 @@ def test_filter_non_specific_nucleotides_filter_all(basic_inputs):
         )
     )
 
+    assert student_emb is not None
+    assert teacher_emb is not None
     assert targets.size(0) == 0
     assert student_logits.size(0) == 0
     assert teacher_logits.size(0) == 0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -115,5 +115,5 @@ disallow_untyped_decorators = false
 disallow_untyped_calls = false
 
 [[tool.mypy.overrides]]
-module = ["datasets.*", "pyfaidx.*", "pynvml.*", "sklearn.*", "transformers.*", "fsspec.*", "gcsfs.*"]
+module = ["datasets.*", "pyfaidx.*", "pynvml.*", "sklearn.*", "transformers.*", "fsspec.*", "gcsfs.*", "mamba_ssm.*"]
 ignore_missing_imports = true


### PR DESCRIPTION
* In an effort to improve the loss/NT correlation, we explore an alternative to 2-term soft logits + hard labels distillation (Hinton style), and incorporate a 3rd term - cosine distance between the embeddings (roughly DistilBERT style)
  * TLDR - the loss/NT correlation is better with this style of distillation for the Caduceus model. We believe with sufficient training time and student size, you can achieve useful levels of performance on the NT downstream tasks
    * Note in our experiments we limit ourselves to at most 24h training runs (Colab limitation)
      * https://wandb.ai/tabtablabs/caduceus_distill/runs/w6balygs
        * Experiment with half the number of blocks (height), and same width as the teacher - roughly 50% of the size. After ~17hrs, we get roughly 88% of the NT scores (ROCAUC and F1)
          * Correlation is better than without the 3rd term, mean (SD): -0.66 (0.11)                                                                                                                            
          
* We’ve opted to not materialize the embeddings, and instead embed the teacher model inference into the distillation itself
    * There’s a couple of reasons why we have opted for this, all of them boil down to reducing (immediate) cost
* DistilBERT assumes equal embedding dimensions (hereinafter `d_model`) between the teacher and student to compute the distance. We then proceed to experiment with a reduced `d_model` for the student model.
    * We’ve tried model surgery, this largely failed due to mamba SSM expectations on residual dimensions. With sufficient finesse this approach may work, but suffice to say it’s non-obvious.
    * In the end adding a projection layer (before logits) and monkey patching the head works, albeit rather hacky.
      * https://wandb.ai/tabtablabs/caduceus_distill/runs/0bsr6fl0
        * Experiment with 15% of the teacher’s size, half the width and half the height. 4x sorter sequence length, $$2^{15}$$ instead of $$2^{17}$$ (to reduce cost we are using L4). We get a similar correlation mean (SD) -0.66 (0.10).

---

Code changes:
 * embed teacher inference in the distillation
 * support resuming experiment from a checkpoint
   * this adjusts the data loader, as well as resumes wandb logging
 * log `d_model` and number of blocks a wandb hyperparameters
 * fix bug with validation schedule over multiple epochs